### PR TITLE
Enable the cookiecutter's `"db"` option

### DIFF
--- a/.cookiecutter/cookiecutter.json
+++ b/.cookiecutter/cookiecutter.json
@@ -12,7 +12,9 @@
     "copyright_holder": "Hypothesis",
     "visibility": "private",
     "console_script": "yes",
+    "postgres": "yes",
     "dependabot_pip_interval": "monthly",
+    "__postgres_port": "5437",
     "__entry_point": "cookiecutter-pypackage-test",
     "__github_url": "https://github.com/hypothesis/cookiecutter-pypackage-test",
     "__pypi_url": "https://pypi.org/project/cookiecutter-pypackage-test"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,13 @@ jobs:
       - run: tox -e lint
   Tests:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:11.5-alpine
+        ports:
+        - 5437:5432
+    env:
+      TEST_DATABASE_URL: postgresql://postgres@localhost:5437/cookiecutter_pypackage_test_test
     strategy:
       matrix:
         python-version: ['3.10', '3.9', '3.8', '3.7']
@@ -38,6 +45,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Create test database
+        run: psql -U postgres -h localhost -p 5437 -c 'CREATE DATABASE cookiecutter_pypackage_test_test'
       - run: python -m pip install 'tox<4'
       - run: tox -e tests
       - name: Upload coverage file
@@ -62,6 +71,13 @@ jobs:
       - run: tox -e coverage
   Functests:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:11.5-alpine
+        ports:
+        - 5437:5432
+    env:
+      TEST_DATABASE_URL: postgresql://postgres@localhost:5437/cookiecutter_pypackage_test_test
     strategy:
       matrix:
         python-version: ['3.10', '3.9', '3.8', '3.7']
@@ -72,5 +88,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Create test database
+        run: psql -U postgres -h localhost -p 5437 -c 'CREATE DATABASE cookiecutter_pypackage_test_test'
       - run: python -m pip install 'tox<4'
       - run: tox -e functests

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ help = help::; @echo $$$$(tput bold)$(strip $(1)):$$$$(tput sgr0) $(strip $(2))
 $(call help,make help,print this help message)
 
 .PHONY: services
+$(call help,make services,start the services that the app needs)
+services: args?=up -d
+services: python
+	@docker compose $(args)
 
 .PHONY: devdata
 
@@ -12,6 +16,11 @@ $(call help,make help,print this help message)
 $(call help,make shell,"launch a Python shell in this project's virtualenv")
 shell: python
 	@pyenv exec tox -qe dev
+
+.PHONY: sql
+$(call help,make sql,"Connect to the dev database with a psql shell")
+sql: python
+	@docker compose exec postgres psql --pset expanded=auto -U postgres
 
 .PHONY: lint
 $(call help,make lint,"lint the code and print any warnings")

--- a/README.md
+++ b/README.md
@@ -60,12 +60,16 @@ First you'll need to install:
   The **Basic GitHub Checkout** method works best on Ubuntu.
   You _don't_ need to set up pyenv's shell integration ("shims"), you can
   [use pyenv without shims](https://github.com/pyenv/pyenv#using-pyenv-without-shims).
+* [Docker Desktop](https://www.docker.com/products/docker-desktop/).
+  On Ubuntu follow [Install on Ubuntu](https://docs.docker.com/desktop/install/ubuntu/).
+  On macOS follow [Install on Mac](https://docs.docker.com/desktop/install/mac-install/).
 
 Then to set up your development environment:
 
 ```terminal
 git clone https://github.com/hypothesis/cookiecutter-pypackage-test.git
 cd cookiecutter-pypackage-test
+make services
 make help
 ```
 

--- a/bin/create-db
+++ b/bin/create-db
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+#
+# Create the given database in Postgres, if it doesn't exist already.
+#
+# Usage:
+#
+#     create-db <DB_NAME>
+make services args="exec postgres psql -U postgres -c 'CREATE DATABASE $1;'" > /dev/null 2>&1 || true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  postgres:
+    image: postgres:11.5-alpine
+    ports:
+      - "127.0.0.1:5437:5432"
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 1s

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,11 @@ deps =
     lint,template: cookiecutter
 depends =
     coverage: tests,py{39,38,37}-tests
+allowlist_externals =
+    tests,functests: sh
 commands =
+    tests: sh bin/create-db cookiecutter_pypackage_test_test
+    functests: sh bin/create-db cookiecutter_pypackage_test_functests
     dev: {posargs:ipython --classic --no-banner --no-confirm-exit}
     format: black src tests bin
     format: isort --atomic src tests bin


### PR DESCRIPTION
Depends on https://github.com/hypothesis/cookiecutters/pull/97.

Testing:

- [x] `make services` works
- [x] `make sql` works
- [x] `make sure` works
- [x] CI passes  