### PR TITLE
Pin to tox<4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - run: python -m pip install tox
+      - run: python -m pip install 'tox<4'
       - run: tox -e checkformatting
   Lint:
     runs-on: ubuntu-latest
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - run: python -m pip install tox
+      - run: python -m pip install 'tox<4'
       - run: tox -e lint
   Tests:
     runs-on: ubuntu-latest
@@ -38,7 +38,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - run: python -m pip install tox
+      - run: python -m pip install 'tox<4'
       - run: tox -e tests
       - name: Upload coverage file
         uses: actions/upload-artifact@v3
@@ -58,7 +58,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: coverage
-      - run: python -m pip install tox
+      - run: python -m pip install 'tox<4'
       - run: tox -e coverage
   Functests:
     runs-on: ubuntu-latest
@@ -72,5 +72,5 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - run: python -m pip install tox
+      - run: python -m pip install 'tox<4'
       - run: tox -e functests

--- a/bin/make_python
+++ b/bin/make_python
@@ -12,7 +12,7 @@ for python_version in 3.10.6 3.9.13 3.8.13 3.7.13; do
     bin_dir=$pyenv_root/versions/$python_version/bin
     if [ ! -f "$bin_dir"/tox ]; then
         pyenv install --skip-existing "$python_version"
-        "$bin_dir"/pip install --disable-pip-version-check tox
+        "$bin_dir"/pip install --disable-pip-version-check 'tox<4'
         pyenv rehash
     fi
 done

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist = tests
-minversion = 3.25.0
 requires =
+    tox>=3.25.0,<4
     tox-envfile
     tox-faster
     tox-run-command


### PR DESCRIPTION
Pin to tox<4 to avoid breakage caused by tox 4.0.0 backwards-incompatibilities.

See https://github.com/hypothesis/cookiecutter-pyapp-test/pull/6 for details.
